### PR TITLE
ops+fix: upgrade to v2.0.0 — x402 compliance, 74 endpoints, Node 24, FRED env

### DIFF
--- a/.github/workflows/api-directory-submit.yml
+++ b/.github/workflows/api-directory-submit.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '.github/workflows/api-directory-submit.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   submit:
     runs-on: ubuntu-latest

--- a/.github/workflows/awesome-list-submit.yml
+++ b/.github/workflows/awesome-list-submit.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 12 * * 1'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   submit-awesome-mcp-servers:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -10,179 +10,197 @@ on:
 jobs:
   deploy-verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check if service is already live
+      - name: Check current live version
         id: health_check
         continue-on-error: true
         run: |
           echo "Checking https://hydra-api-nlnj.onrender.com/health ..."
           HTTP_CODE=$(curl -s -o /tmp/health_response.json -w "%{http_code}" \
-            --max-time 15 \
+            --max-time 20 \
             https://hydra-api-nlnj.onrender.com/health 2>/dev/null || echo "000")
           echo "HTTP status: $HTTP_CODE"
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "status=live" >> $GITHUB_OUTPUT
-            echo "✅ Service is LIVE"
-            cat /tmp/health_response.json | python3 -m json.tool 2>/dev/null || cat /tmp/health_response.json
+          EXPECTED=$(grep -E 'APP_VERSION' config/settings.py | head -1 | sed -E 's/.*"([0-9.]+)".*/\1/')
+          LIVE=$(python3 -c "import sys,json;print(json.load(open('/tmp/health_response.json')).get('version',''))" 2>/dev/null || echo "")
+          echo "expected=$EXPECTED" >> $GITHUB_OUTPUT
+          echo "live=$LIVE" >> $GITHUB_OUTPUT
+          if [ "$HTTP_CODE" = "200" ] && [ "$LIVE" = "$EXPECTED" ]; then
+            echo "status=current" >> $GITHUB_OUTPUT
+            echo "✅ Service is LIVE and CURRENT (v$LIVE)"
+          elif [ "$HTTP_CODE" = "200" ]; then
+            echo "status=stale" >> $GITHUB_OUTPUT
+            echo "⚠️ Service is live but STALE (live=$LIVE, expected=$EXPECTED)"
           else
             echo "status=down" >> $GITHUB_OUTPUT
-            echo "⚠️ Service returned HTTP $HTTP_CODE — may be sleeping or not deployed"
+            echo "⚠️ Service returned HTTP $HTTP_CODE"
           fi
 
-      - name: Trigger Render deploy hook (if secret exists)
-        if: steps.health_check.outputs.status != 'live'
+      - name: Trigger Render deploy via deploy hook
+        if: steps.health_check.outputs.status != 'current'
         continue-on-error: true
         env:
           RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
         run: |
           if [ -n "$RENDER_DEPLOY_HOOK" ]; then
-            echo "🚀 Triggering Render deploy hook..."
-            curl -s -X POST "$RENDER_DEPLOY_HOOK" --max-time 30
-            echo ""
-            echo "Deploy hook triggered. Waiting for service to start..."
+            echo "🚀 Triggering Render deploy hook (clear cache)..."
+            RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
+              "${RENDER_DEPLOY_HOOK}?clearCache=clear" \
+              --max-time 30)
+            HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+            echo "Deploy hook response: $HTTP_STATUS"
+            echo "Waiting for Render to pick up the deploy..."
           else
-            echo "ℹ️ No RENDER_DEPLOY_HOOK secret configured."
+            echo "ℹ️ RENDER_DEPLOY_HOOK secret not set."
             echo ""
-            echo "To enable auto-deploy, either:"
-            echo "  1. Connect this repo to Render at https://render.com (uses render.yaml blueprint)"
-            echo "  2. Or add a RENDER_DEPLOY_HOOK secret with your Render deploy hook URL"
+            echo "To enable fully-automated deploys:"
+            echo "  Render dashboard → hydra-api → Settings → Deploy Hook URL"
+            echo "  → GitHub repo → Settings → Secrets → RENDER_DEPLOY_HOOK"
             echo ""
-            echo "The render.yaml blueprint is ready — Render will auto-configure everything."
+            echo "Alternatively, in Render dashboard:"
+            echo "  hydra-api → Deploys → Manual Deploy → Clear build cache & deploy"
           fi
 
-      - name: Wait for service to come up
-        if: steps.health_check.outputs.status != 'live'
+      - name: Trigger Render deploy via API key
+        if: steps.health_check.outputs.status != 'current'
+        continue-on-error: true
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          if [ -n "$RENDER_API_KEY" ]; then
+            echo "🔑 Triggering Render deploy via API key..."
+            # Find the service ID
+            SVC_ID=$(curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
+              "https://api.render.com/v1/services?name=hydra-api&type=web_service&limit=5" \
+              | python3 -c "import sys,json;svcs=json.load(sys.stdin);print(svcs[0]['service']['id'] if svcs else '')" 2>/dev/null || echo "")
+            if [ -n "$SVC_ID" ]; then
+              echo "Service ID: $SVC_ID"
+              DEPLOY_RESP=$(curl -s -w "\nHTTP_STATUS:%{http_code}" \
+                -X POST \
+                -H "Authorization: Bearer $RENDER_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{"clearCache":"clear"}' \
+                "https://api.render.com/v1/services/$SVC_ID/deploys")
+              HTTP_STATUS=$(echo "$DEPLOY_RESP" | grep "HTTP_STATUS:" | cut -d: -f2)
+              echo "Render API deploy triggered: HTTP $HTTP_STATUS"
+            else
+              echo "Could not find service ID for hydra-api"
+            fi
+          fi
+
+      - name: Wait for deploy to complete (up to 8 min)
+        if: steps.health_check.outputs.status != 'current'
         id: wait_check
         run: |
-          echo "Waiting for service to respond (checking every 30s for up to 5 min)..."
-          for i in 1 2 3 4 5 6 7 8 9 10; do
+          EXPECTED="${{ steps.health_check.outputs.expected }}"
+          echo "Waiting for v$EXPECTED to go live (checking every 30s for up to 8 min)..."
+          for i in $(seq 1 16); do
             sleep 30
             HTTP_CODE=$(curl -s -o /tmp/health_retry.json -w "%{http_code}" \
-              --max-time 15 \
+              --max-time 20 \
               https://hydra-api-nlnj.onrender.com/health 2>/dev/null || echo "000")
-            echo "Attempt $i: HTTP $HTTP_CODE"
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "status=live" >> $GITHUB_OUTPUT
-              echo "✅ Service is now LIVE!"
-              cat /tmp/health_retry.json | python3 -m json.tool 2>/dev/null || true
+            LIVE=$(python3 -c "import sys,json;print(json.load(open('/tmp/health_retry.json')).get('version',''))" 2>/dev/null || echo "")
+            echo "Attempt $i: HTTP $HTTP_CODE | version=$LIVE"
+            if [ "$HTTP_CODE" = "200" ] && [ "$LIVE" = "$EXPECTED" ]; then
+              echo "status=current" >> $GITHUB_OUTPUT
+              echo "✅ v$LIVE is now LIVE!"
+              python3 -m json.tool /tmp/health_retry.json 2>/dev/null || true
               exit 0
             fi
           done
-          echo "status=down" >> $GITHUB_OUTPUT
-          echo "❌ Service did not come up within 5 minutes"
+          echo "status=stale" >> $GITHUB_OUTPUT
+          echo "❌ Deploy did not complete within 8 minutes — check Render dashboard"
 
-      - name: Verify all endpoints respond
-        if: steps.health_check.outputs.status == 'live' || steps.wait_check.outputs.status == 'live'
+      - name: Verify discovery manifests and endpoints
+        if: steps.health_check.outputs.status == 'current' || steps.wait_check.outputs.status == 'current'
         run: |
           BASE="https://hydra-api-nlnj.onrender.com"
           echo "=== Endpoint Verification ==="
-          
-          echo -n "GET  /health ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/health" --max-time 10
-          echo ""
-          
-          echo -n "GET  /pricing ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/pricing" --max-time 10
-          echo ""
-          
-          echo -n "GET  /docs ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/docs" --max-time 10
-          echo ""
-          
-          echo -n "GET  /openapi.json ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/openapi.json" --max-time 10
-          echo ""
-          
-          echo -n "GET  /.well-known/x402.json ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/.well-known/x402.json" --max-time 10
-          echo ""
-          
-          echo -n "GET  /.well-known/ai-plugin.json ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/.well-known/ai-plugin.json" --max-time 10
-          echo ""
+          FAIL=0
 
-          echo -n "GET  /.well-known/mcp.json ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/.well-known/mcp.json" --max-time 10
-          echo ""
+          check() {
+            local METHOD=$1 URL=$2 EXPECT=$3 LABEL=$4
+            BODY='-d {}'
+            [ "$METHOD" = "GET" ] && BODY=""
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" -X "$METHOD" \
+              -H "Content-Type: application/json" $BODY \
+              "$BASE$URL" --max-time 15)
+            if [ "$CODE" = "$EXPECT" ]; then
+              echo "✅ $METHOD $URL → $CODE"
+            else
+              echo "❌ $METHOD $URL → $CODE (expected $EXPECT)"
+              FAIL=1
+            fi
+          }
 
-          echo -n "GET  /.well-known/agent.json ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/.well-known/agent.json" --max-time 10
-          echo ""
+          # Free endpoints → 200
+          check GET /health 200 "health"
+          check GET /pricing 200 "pricing"
+          check GET /docs 200 "docs"
+          check GET /openapi.json 200 "openapi"
+          check GET /.well-known/x402.json 200 "x402 manifest"
+          check GET /.well-known/mcp.json 200 "mcp manifest"
+          check GET /.well-known/agent.json 200 "agent card"
+          check GET /.well-known/agent-card.json 200 "agent card (legacy)"
+          check GET /.well-known/llms.txt 200 "llms.txt"
+          check GET /.well-known/ai-plugin.json 200 "ai-plugin.json"
+          check GET /mcp 200 "MCP server"
+          check GET /v1/markets 200 "markets (free)"
 
-          echo -n "GET  /.well-known/agent-card.json ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/.well-known/agent-card.json" --max-time 10
-          echo ""
+          # Paid endpoints → 402 (payment required)
+          check POST /v1/regulatory/scan 402 "regulatory/scan"
+          check POST /v1/fed/signal 402 "fed/signal"
+          check POST /v1/markets/signal/test 402 "markets/signal"
+          check GET /v1/market/prices 402 "market/prices"
+          check POST /v1/extract/url 402 "extract/url"
 
-          echo -n "GET  /.well-known/llms.txt ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/.well-known/llms.txt" --max-time 10
+          if [ "$FAIL" = "1" ]; then
+            echo "::error::Some endpoint checks failed — see above"
+            exit 1
+          fi
           echo ""
+          echo "✅ All endpoint checks passed"
 
-          echo -n "GET  /mcp (MCP server) ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/mcp" --max-time 10
-          echo ""
-
-          echo -n "GET  /v1/markets (free discovery) ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/v1/markets" --max-time 10
-          echo ""
-          
-          echo -n "GET  /v1/markets/discovery (free) ... "
-          curl -s -o /dev/null -w "%{http_code}" "$BASE/v1/markets/discovery" --max-time 10
-          echo ""
-          
-          echo -n "POST /v1/regulatory/scan (expect 402) ... "
-          curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/v1/regulatory/scan" \
-            -H "Content-Type: application/json" \
-            -d '{"business_description":"test crypto exchange in Wyoming","jurisdiction":"US"}' \
-            --max-time 10
-          echo ""
-          
-          echo -n "POST /v1/fed/signal (expect 402) ... "
-          curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/v1/fed/signal" \
-            -H "Content-Type: application/json" \
-            -d '{}' \
-            --max-time 10
-          echo ""
-          
-          echo ""
-          echo "Free endpoints should return 200. Paid endpoints should return 402."
-          echo "402 = x402 payment required (correct behavior — payment gateway working)."
-
-      - name: Report deployment status (fails on stale deploy)
+      - name: Report deployment status
         if: always()
         run: |
           echo "============================================"
           echo " HYDRA DEPLOYMENT STATUS REPORT"
           echo "============================================"
           BASE="https://hydra-api-nlnj.onrender.com"
-          # Reachability ≠ current code. Compare the LIVE version to the repo's
-          # APP_VERSION and confirm a discovery manifest serves. This catches the
-          # "frozen on an old build" failure that plain 200-checks miss.
           EXPECTED=$(grep -E 'APP_VERSION' config/settings.py | head -1 | sed -E 's/.*"([0-9.]+)".*/\1/')
-          LIVE=$(curl -s --max-time 20 "$BASE/health" | python3 -c "import sys,json;print(json.load(sys.stdin).get('version',''))" 2>/dev/null || echo "")
+          LIVE=$(curl -s --max-time 20 "$BASE/health" \
+            | python3 -c "import sys,json;print(json.load(sys.stdin).get('version',''))" 2>/dev/null || echo "")
           X402=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$BASE/.well-known/x402.json" || echo "000")
+          AUTOMATON=$(curl -s --max-time 20 "$BASE/health" \
+            | python3 -c "import sys,json;h=json.load(sys.stdin);a=h.get('automaton');print('RUNNING phase='+a.get('phase','?') if a else 'null')" 2>/dev/null || echo "unknown")
           echo "Repo APP_VERSION : ${EXPECTED:-unknown}"
           echo "Live /health ver : ${LIVE:-unreachable}"
           echo "x402 manifest    : $X402 (expect 200)"
+          echo "Automaton status : $AUTOMATON"
           echo ""
           FAIL=0
           if [ -z "$LIVE" ]; then echo "❌ Service unreachable."; FAIL=1; fi
           if [ -n "$EXPECTED" ] && [ -n "$LIVE" ] && [ "$LIVE" != "$EXPECTED" ]; then
             echo "❌ STALE DEPLOY: live=$LIVE but repo=$EXPECTED — Render is NOT serving current master."
-            echo "   Fix in Render dashboard: confirm service is connected to master with"
-            echo "   autoDeploy on, check the Deploys tab for build failures, then Manual Deploy"
-            echo "   (Clear build cache & deploy). render.yaml blueprint is ready."
+            echo "   Fix: Set RENDER_DEPLOY_HOOK or RENDER_API_KEY secret, or manually deploy in Render dashboard."
             FAIL=1
+          elif [ -n "$LIVE" ] && [ "$LIVE" = "$EXPECTED" ]; then
+            echo "✅ LIVE version matches repo version (v$LIVE)"
           fi
           if [ "$X402" != "200" ]; then
             echo "❌ Discovery manifest /.well-known/x402.json → $X402 (should be 200)."
             FAIL=1
+          else
+            echo "✅ x402 discovery manifest serving"
           fi
           if [ "$FAIL" = "1" ]; then
             echo "::error::HYDRA deployment is stale or broken — see details above."
             exit 1
           fi
-          echo "✅ HYDRA is LIVE and CURRENT (v$LIVE), discovery manifests serving."
+          echo "✅ HYDRA is LIVE and CURRENT (v$LIVE), all systems operational."
           echo "============================================"

--- a/.github/workflows/discovery-register.yml
+++ b/.github/workflows/discovery-register.yml
@@ -8,6 +8,9 @@ on:
       - 'config/settings.py'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   register:
     runs-on: ubuntu-latest

--- a/.github/workflows/hydra-autonomous.yml
+++ b/.github/workflows/hydra-autonomous.yml
@@ -8,6 +8,9 @@ on:
     branches: [master]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # ── Phase 1: Verify deployment is live ──────────────────────
   health-check:

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -4,6 +4,9 @@ on:
     - cron: '*/14 * * * *'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ping:
     runs-on: ubuntu-latest

--- a/render.yaml
+++ b/render.yaml
@@ -31,3 +31,7 @@ services:
         sync: false  # Must be set manually in Render dashboard
       - key: PYTHON_VERSION
         value: "3.11.6"
+      - key: FRED_API_KEY
+        sync: false  # Set in Render dashboard — enables 28 FRED economic data series
+      - key: HYDRA_RELAYER_URL
+        sync: false  # Optional: gasless EIP-3009 relay URL

--- a/src/x402/middleware.py
+++ b/src/x402/middleware.py
@@ -418,11 +418,40 @@ class X402PaymentMiddleware(BaseHTTPMiddleware):
 
     @staticmethod
     def _payment_required_response(path: str, pricing: dict) -> JSONResponse:
-        """Return a standards-compliant 402 Payment Required response."""
+        """Return a standards-compliant 402 Payment Required response.
+
+        Body follows the x402 protocol spec (coinbase/x402) with a top-level
+        ``accepts`` array so that x402scan, x402 Bazaar, and all x402-compatible
+        clients can parse payment requirements without custom headers.
+
+        Spec: https://x402.org/spec
+        """
         sample = _get_sample_response(path)
+
+        # ── Standard x402 accepts object (top-level, required by spec crawlers) ──
+        x402_accept = {
+            "scheme": "exact",
+            "network": f"eip155:{CHAIN_ID}",
+            "maxAmountRequired": str(pricing["amount_base_units"]),
+            "resource": f"https://hydra-api-nlnj.onrender.com{path}",
+            "description": pricing["description"],
+            "mimeType": "application/json",
+            "payTo": WALLET_ADDRESS,
+            "maxTimeoutSeconds": 900,
+            "asset": USDC_CONTRACT_ADDRESS,
+            "extra": {
+                "name": "USD Coin",
+                "version": "2",
+                "chainId": CHAIN_ID,
+            },
+        }
+
         body = {
-            "status": 402,
-            "message": "Payment Required",
+            # ── Standard x402 root fields (required by spec crawlers) ──────────
+            "x402Version": 2,
+            "error": "Payment Required",
+            "accepts": [x402_accept],
+            # ── HYDRA extended fields (backward compat + rich discovery) ───────
             "endpoint": path,
             "description": pricing["description"],
             "price": {
@@ -438,7 +467,7 @@ class X402PaymentMiddleware(BaseHTTPMiddleware):
                     "wallet": WALLET_ADDRESS,
                     "token_address": USDC_CONTRACT_ADDRESS,
                     "facilitator": "https://x402.org/facilitator",
-                    "protocol_version": 1,
+                    "protocol_version": 2,
                     "scheme": "exact",
                     "network": f"eip155:{CHAIN_ID}",
                     "proof_header": "X-PAYMENT",
@@ -456,7 +485,7 @@ class X402PaymentMiddleware(BaseHTTPMiddleware):
                     "token_address": USDC_CONTRACT_ADDRESS,
                     "chain": "base",
                     "chain_id": CHAIN_ID,
-                    "header": f"X-Payment-Proof: 0x_your_transaction_hash",
+                    "header": "X-Payment-Proof: 0x_your_transaction_hash",
                     "steps": [
                         f"Send {pricing['amount_usdc']} USDC to {WALLET_ADDRESS} on Base (chain ID {CHAIN_ID})",
                         "Copy the transaction hash from your wallet or block explorer",

--- a/static/.well-known/llms.txt
+++ b/static/.well-known/llms.txt
@@ -1,6 +1,6 @@
 # HYDRA
 
-> Autonomous regulatory + market intelligence API with 66+ paid endpoints. Live crypto prices, DeFi yields, stablecoin pegs, multi-chain gas, Fear & Greed, forex. Real-time data from 18+ sources. Market-calibrated Fed rate probabilities. Alpha signals with edge analysis. From $0.001 USDC on Base L2.
+> Autonomous regulatory + market intelligence API with 74+ paid endpoints. Live crypto prices, DeFi yields, stablecoin pegs, multi-chain gas, Fear & Greed, forex. Real-time data from 22+ authoritative sources. Market-calibrated Fed rate probabilities. Alpha signals with edge analysis. From $0.001 USDC on Base L2.
 
 HYDRA is the infrastructure layer of the x402 economy. It provides live market data (CoinGecko crypto prices, DeFi Llama TVL/yields/stablecoins, Fear & Greed Index, multi-chain gas from public RPCs, ECB forex rates), real-time economic data from 18+ authoritative sources (FRED, BLS, Treasury, SEC EDGAR, Federal Register, FDIC BankFind, Congress.gov, Fed RSS, Kalshi KXFED, Polymarket, CoinGecko, DeFi Llama, Alternative.me, ECB), composite intelligence products (alpha signals with Kelly sizing, market-calibrated risk scores, regulatory pulse), prediction market signals with Kalshi KXFED-calibrated Fed rate probabilities (60% market / 40% model blend), FOMC decision classification within 30 seconds, push alerts, web extraction, format conversion, developer tools, and oracle data for UMA/Chainlink.
 

--- a/static/.well-known/x402.json
+++ b/static/.well-known/x402.json
@@ -1,6 +1,6 @@
 {
   "name": "HYDRA",
-  "description": "Autonomous regulatory + market intelligence API with 66+ paid endpoints. Live crypto prices (CoinGecko), DeFi TVL/yields (DeFi Llama), stablecoin peg tracking, multi-chain gas, Fear & Greed Index, ECB forex. Real-time data from 18+ sources (FRED, BLS, Treasury, SEC EDGAR, Federal Register, FDIC, Kalshi KXFED, Polymarket, CoinGecko, DeFi Llama, ECB). Prediction market signals with market-calibrated Fed rate probabilities. Alpha reports with edge analysis and Kelly sizing. From $0.001 USDC on Base L2.",
+  "description": "Autonomous regulatory + market intelligence API with 74+ paid endpoints. Live crypto prices (CoinGecko), DeFi TVL/yields (DeFi Llama), stablecoin peg tracking, multi-chain gas, Fear & Greed Index, ECB forex. Real-time data from 22+ authoritative sources (FRED, BLS, Treasury, SEC EDGAR, Federal Register, FDIC, Kalshi KXFED, Polymarket, CoinGecko, DeFi Llama, ECB). Prediction market signals with market-calibrated Fed rate probabilities. Alpha reports with edge analysis and Kelly sizing. From $0.001 USDC on Base L2.",
   "url": "https://hydra-api-nlnj.onrender.com",
   "x402Version": 1,
   "payment": {
@@ -13,84 +13,474 @@
     "facilitator": "https://x402.org/facilitator"
   },
   "endpoints": [
-    {"path": "/v1/markets", "method": "GET", "price": "free", "description": "Active regulatory prediction markets across Polymarket and Kalshi"},
-    {"path": "/v1/markets/feed", "method": "GET", "price": "0.10", "description": "Micro regulatory event feed matched to prediction markets"},
-    {"path": "/v1/markets/events", "method": "POST", "price": "0.50", "description": "Classified regulatory events from SEC, CFTC, Fed, FinCEN"},
-    {"path": "/v1/markets/signal/{market_id}", "method": "POST", "price": "2.00", "description": "Scored regulatory signal for one prediction market"},
-    {"path": "/v1/markets/signals", "method": "POST", "price": "5.00", "description": "Bulk scored signals for all regulatory prediction markets"},
-    {"path": "/v1/markets/alpha", "method": "POST", "price": "10.00", "description": "Premium alpha report with edge analysis, Kelly sizing, trade verdict"},
-    {"path": "/v1/fed/signal", "method": "POST", "price": "5.00", "description": "Pre-FOMC signal with rate probabilities and Fed speech analysis"},
-    {"path": "/v1/fed/decision", "method": "POST", "price": "25.00", "description": "Real-time FOMC decision classification within 30 seconds of release"},
-    {"path": "/v1/fed/resolution", "method": "POST", "price": "50.00", "description": "FOMC resolution verdict for UMA/Kalshi/Polymarket oracle submission"},
-    {"path": "/v1/oracle/uma", "method": "POST", "price": "5.00", "description": "UMA Optimistic Oracle assertion data with evidence chain"},
-    {"path": "/v1/oracle/chainlink", "method": "POST", "price": "5.00", "description": "Chainlink External Adapter response format"},
-    {"path": "/v1/markets/resolution", "method": "POST", "price": "25.00", "description": "Professional resolution verdict for prediction market settlement"},
-    {"path": "/v1/regulatory/scan", "method": "POST", "price": "2.00", "description": "Full regulatory risk scan against all applicable frameworks"},
-    {"path": "/v1/regulatory/changes", "method": "POST", "price": "1.00", "description": "Recent regulatory changes classified by agency and impact"},
-    {"path": "/v1/regulatory/jurisdiction", "method": "POST", "price": "3.00", "description": "Jurisdiction comparison with compliance cost modeling"},
-    {"path": "/v1/regulatory/query", "method": "POST", "price": "1.00", "description": "Regulatory Q&A with statutory citations"},
-    {"path": "/v1/util/scrape", "method": "POST", "price": "0.005", "description": "Web scrape — URL to clean structured text"},
-    {"path": "/v1/util/crypto/price", "method": "GET", "price": "0.001", "description": "Token price lookup with 24h change and market cap"},
-    {"path": "/v1/util/rss", "method": "POST", "price": "0.002", "description": "RSS/Atom feed to structured JSON"},
-    {"path": "/v1/util/crypto/balance", "method": "GET", "price": "0.001", "description": "Wallet ETH and USDC balance on Base L2"},
-    {"path": "/v1/util/gas", "method": "GET", "price": "0.001", "description": "Base L2 gas prices with estimated costs for transfers, swaps, mints"},
-    {"path": "/v1/util/tx", "method": "GET", "price": "0.001", "description": "Transaction receipt lookup — status, gas used, block number"},
-    {"path": "/v1/batch", "method": "POST", "price": "0.01", "description": "Batch up to 5 utility calls in one request — saves gas vs individual payments"},
-    {"path": "/v1/extract/url", "method": "POST", "price": "0.01", "description": "Structured web extraction — title, headings, clean text, links, OpenGraph metadata"},
-    {"path": "/v1/extract/multi", "method": "POST", "price": "0.05", "description": "Batch extraction from up to 5 URLs in parallel"},
-    {"path": "/v1/extract/search", "method": "GET", "price": "0.02", "description": "Web search with structured result extraction — titles, snippets, URLs"},
-    {"path": "/v1/check/url", "method": "GET", "price": "0.005", "description": "URL health check — status code, response time, redirect chain, content type"},
-    {"path": "/v1/check/dns", "method": "GET", "price": "0.005", "description": "DNS record lookup — A, AAAA, MX, TXT, NS, CNAME via DNS-over-HTTPS"},
-    {"path": "/v1/check/ssl", "method": "GET", "price": "0.005", "description": "SSL certificate inspection — issuer, expiry, SANs, days remaining"},
-    {"path": "/v1/check/headers", "method": "GET", "price": "0.003", "description": "HTTP response headers with security headers analysis and score"},
-    {"path": "/v1/convert/html2md", "method": "POST", "price": "0.005", "description": "HTML to Markdown — preserves headings, lists, links, code blocks, tables"},
-    {"path": "/v1/convert/json2csv", "method": "POST", "price": "0.003", "description": "JSON array to CSV with auto-detected headers"},
-    {"path": "/v1/convert/csv2json", "method": "POST", "price": "0.003", "description": "CSV text to JSON array of objects"},
-    {"path": "/v1/tools/hash", "method": "POST", "price": "0.001", "description": "Hash text with SHA-256, SHA-512, MD5, SHA-1, or SHA3-256"},
-    {"path": "/v1/tools/encode", "method": "POST", "price": "0.001", "description": "Encode/decode text — Base64, URL encoding, hex"},
-    {"path": "/v1/tools/diff", "method": "POST", "price": "0.003", "description": "Unified diff between two texts with change stats and similarity ratio"},
-    {"path": "/v1/tools/validate/json", "method": "POST", "price": "0.001", "description": "JSON syntax validation with pretty-print and structure info"},
-    {"path": "/v1/tools/validate/email", "method": "POST", "price": "0.002", "description": "Email format validation with MX record check"},
-    {"path": "/v1/data/wikipedia", "method": "GET", "price": "0.01", "description": "Wikipedia article summary — extract, thumbnail, description, page URL"},
-    {"path": "/v1/data/arxiv", "method": "GET", "price": "0.02", "description": "arXiv academic paper search — titles, authors, abstracts, PDF links"},
-    {"path": "/v1/data/edgar", "method": "GET", "price": "0.02", "description": "SEC EDGAR filing search — 10-K, 10-Q, 8-K by company, ticker, or keyword"},
-    {"path": "/v1/x402/directory", "method": "GET", "price": "free", "description": "Canonical x402 ecosystem directory — all known x402 services indexed hourly"},
-    {"path": "/v1/x402/stats", "method": "GET", "price": "free", "description": "x402 ecosystem aggregate statistics — services by chain, category, growth"},
-    {"path": "/v1/x402/status", "method": "GET", "price": "0.005", "description": "Real-time health and capability check of any x402 service"},
-    {"path": "/v1/x402/route", "method": "POST", "price": "0.001", "description": "Intelligent x402 service routing — find the best service for your need"},
-    {"path": "/v1/intelligence/pulse", "method": "GET", "price": "0.50", "description": "Hourly regulatory pulse — aggregated agency activity with composite risk signal"},
-    {"path": "/v1/intelligence/alpha", "method": "GET", "price": "5.00", "description": "Composite alpha signal — regulatory + Fed + prediction markets + momentum"},
-    {"path": "/v1/intelligence/risk-score", "method": "GET", "price": "2.00", "description": "Real-time 0-100 regulatory risk score for any token or protocol"},
-    {"path": "/v1/intelligence/digest", "method": "GET", "price": "1.00", "description": "Daily regulatory + market digest for compliance teams and trading agents"},
-    {"path": "/v1/intelligence/economic-snapshot", "method": "GET", "price": "0.50", "description": "Atomic real-time economic snapshot — FRED, BLS, Treasury, FDIC, Federal Register"},
-    {"path": "/v1/intelligence/regulatory-pulse-live", "method": "GET", "price": "0.50", "description": "Live regulatory pulse — SEC EDGAR, Federal Register, Congress bill tracker"},
-    {"path": "/v1/intelligence/bank-failures", "method": "GET", "price": "0.25", "description": "FDIC bank failure monitor — recent closures, resolution details, losses"},
-    {"path": "/v1/alerts/subscribe", "method": "POST", "price": "0.10", "description": "Push alert subscription — webhook delivery of regulatory events. $0.10/100 alerts"},
-    {"path": "/v1/alerts/feed", "method": "GET", "price": "0.05", "description": "Real-time regulatory alert feed — last 24 hours of detected events"},
-    {"path": "/v1/alerts/status", "method": "GET", "price": "free", "description": "Check alert subscription status and remaining alerts"},
-    {"path": "/v1/portfolio/scan", "method": "POST", "price": "10.00", "description": "Portfolio-level regulatory scan — up to 20 assets with aggregate risk"},
-    {"path": "/v1/portfolio/watchlist", "method": "POST", "price": "2.00", "description": "Portfolio watchlist — agency mentions and alert levels for up to 20 assets"},
-    {"path": "/v1/portfolio/market-brief", "method": "GET", "price": "3.00", "description": "Executive market brief — regulatory + Fed + prediction markets in one view"},
-    {"path": "/v1/orchestrate", "method": "POST", "price": "0.05", "description": "Multi-step orchestration — execute up to 10 HYDRA calls in one request"},
-    {"path": "/v1/market/prices", "method": "GET", "price": "0.001", "description": "Live crypto prices, market caps, 24h change via CoinGecko — up to 20 coins"},
-    {"path": "/v1/market/global", "method": "GET", "price": "0.001", "description": "Global crypto market — total market cap, BTC/ETH dominance, 24h volume"},
-    {"path": "/v1/market/trending", "method": "GET", "price": "0.001", "description": "Top trending cryptocurrencies — most searched in last 24h"},
-    {"path": "/v1/market/fear-greed", "method": "GET", "price": "0.001", "description": "Crypto Fear & Greed Index — 0-100 score with 7-day history"},
-    {"path": "/v1/market/gas", "method": "GET", "price": "0.001", "description": "Live gas prices across Ethereum, Base, Arbitrum, Optimism, Polygon"},
-    {"path": "/v1/market/stablecoins", "method": "GET", "price": "0.002", "description": "Top 20 stablecoins with circulating supply and real-time peg deviation"},
-    {"path": "/v1/market/defi/tvl", "method": "GET", "price": "0.002", "description": "Top 25 DeFi protocols by TVL with 1d/7d change via DeFi Llama"},
-    {"path": "/v1/market/defi/yields", "method": "GET", "price": "0.005", "description": "Top DeFi yield opportunities — APY, TVL, IL risk across all chains"},
-    {"path": "/v1/market/defi/chains", "method": "GET", "price": "0.001", "description": "Top 30 blockchains ranked by total DeFi TVL"},
-    {"path": "/v1/market/forex", "method": "GET", "price": "0.001", "description": "Major forex rates from the European Central Bank — ~30 pairs"},
-    {"path": "/v1/market/snapshot", "method": "GET", "price": "0.05", "description": "Complete market snapshot — crypto, global, fear/greed, gas, stablecoins"},
-    {"path": "/v1/market/binance/prices", "method": "GET", "price": "0.002", "description": "Real-time Binance prices with 24h volume, high/low, trades, bid/ask"},
-    {"path": "/v1/market/binance/orderbook", "method": "GET", "price": "0.005", "description": "Binance order book — bids, asks, spread for any trading pair"},
-    {"path": "/v1/market/binance/klines", "method": "GET", "price": "0.005", "description": "Binance OHLCV candlestick data for charting and technical analysis"},
-    {"path": "/v1/market/dex/token", "method": "GET", "price": "0.01", "description": "All DEX pairs for a token across all chains via DexScreener"},
-    {"path": "/v1/market/dex/search", "method": "GET", "price": "0.005", "description": "Search DEX pairs by name, symbol, or address across all chains"},
-    {"path": "/v1/market/bitcoin/fees", "method": "GET", "price": "0.002", "description": "Bitcoin fees, mempool stats, hashrate, difficulty — real-time"},
-    {"path": "/v1/market/bitcoin/lightning", "method": "GET", "price": "0.002", "description": "Bitcoin Lightning Network — nodes, channels, capacity, fee rates"},
-    {"path": "/v1/market/treasury/auctions", "method": "GET", "price": "0.005", "description": "U.S. Treasury auction results — yield, bid-to-cover ratio (Tier 1 gov)"}
+    {
+      "path": "/v1/markets",
+      "method": "GET",
+      "price": "free",
+      "description": "Active regulatory prediction markets across Polymarket and Kalshi"
+    },
+    {
+      "path": "/v1/markets/feed",
+      "method": "GET",
+      "price": "0.10",
+      "description": "Micro regulatory event feed matched to prediction markets"
+    },
+    {
+      "path": "/v1/markets/events",
+      "method": "POST",
+      "price": "0.50",
+      "description": "Classified regulatory events from SEC, CFTC, Fed, FinCEN"
+    },
+    {
+      "path": "/v1/markets/signal/{market_id}",
+      "method": "POST",
+      "price": "2.00",
+      "description": "Scored regulatory signal for one prediction market"
+    },
+    {
+      "path": "/v1/markets/signals",
+      "method": "POST",
+      "price": "5.00",
+      "description": "Bulk scored signals for all regulatory prediction markets"
+    },
+    {
+      "path": "/v1/markets/alpha",
+      "method": "POST",
+      "price": "10.00",
+      "description": "Premium alpha report with edge analysis, Kelly sizing, trade verdict"
+    },
+    {
+      "path": "/v1/fed/signal",
+      "method": "POST",
+      "price": "5.00",
+      "description": "Pre-FOMC signal with rate probabilities and Fed speech analysis"
+    },
+    {
+      "path": "/v1/fed/decision",
+      "method": "POST",
+      "price": "25.00",
+      "description": "Real-time FOMC decision classification within 30 seconds of release"
+    },
+    {
+      "path": "/v1/fed/resolution",
+      "method": "POST",
+      "price": "50.00",
+      "description": "FOMC resolution verdict for UMA/Kalshi/Polymarket oracle submission"
+    },
+    {
+      "path": "/v1/oracle/uma",
+      "method": "POST",
+      "price": "5.00",
+      "description": "UMA Optimistic Oracle assertion data with evidence chain"
+    },
+    {
+      "path": "/v1/oracle/chainlink",
+      "method": "POST",
+      "price": "5.00",
+      "description": "Chainlink External Adapter response format"
+    },
+    {
+      "path": "/v1/markets/resolution",
+      "method": "POST",
+      "price": "25.00",
+      "description": "Professional resolution verdict for prediction market settlement"
+    },
+    {
+      "path": "/v1/regulatory/scan",
+      "method": "POST",
+      "price": "2.00",
+      "description": "Full regulatory risk scan against all applicable frameworks"
+    },
+    {
+      "path": "/v1/regulatory/changes",
+      "method": "POST",
+      "price": "1.00",
+      "description": "Recent regulatory changes classified by agency and impact"
+    },
+    {
+      "path": "/v1/regulatory/jurisdiction",
+      "method": "POST",
+      "price": "3.00",
+      "description": "Jurisdiction comparison with compliance cost modeling"
+    },
+    {
+      "path": "/v1/regulatory/query",
+      "method": "POST",
+      "price": "1.00",
+      "description": "Regulatory Q&A with statutory citations"
+    },
+    {
+      "path": "/v1/util/scrape",
+      "method": "POST",
+      "price": "0.005",
+      "description": "Web scrape \u2014 URL to clean structured text"
+    },
+    {
+      "path": "/v1/util/crypto/price",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Token price lookup with 24h change and market cap"
+    },
+    {
+      "path": "/v1/util/rss",
+      "method": "POST",
+      "price": "0.002",
+      "description": "RSS/Atom feed to structured JSON"
+    },
+    {
+      "path": "/v1/util/crypto/balance",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Wallet ETH and USDC balance on Base L2"
+    },
+    {
+      "path": "/v1/util/gas",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Base L2 gas prices with estimated costs for transfers, swaps, mints"
+    },
+    {
+      "path": "/v1/util/tx",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Transaction receipt lookup \u2014 status, gas used, block number"
+    },
+    {
+      "path": "/v1/batch",
+      "method": "POST",
+      "price": "0.01",
+      "description": "Batch up to 5 utility calls in one request \u2014 saves gas vs individual payments"
+    },
+    {
+      "path": "/v1/extract/url",
+      "method": "POST",
+      "price": "0.01",
+      "description": "Structured web extraction \u2014 title, headings, clean text, links, OpenGraph metadata"
+    },
+    {
+      "path": "/v1/extract/multi",
+      "method": "POST",
+      "price": "0.05",
+      "description": "Batch extraction from up to 5 URLs in parallel"
+    },
+    {
+      "path": "/v1/extract/search",
+      "method": "GET",
+      "price": "0.02",
+      "description": "Web search with structured result extraction \u2014 titles, snippets, URLs"
+    },
+    {
+      "path": "/v1/check/url",
+      "method": "GET",
+      "price": "0.005",
+      "description": "URL health check \u2014 status code, response time, redirect chain, content type"
+    },
+    {
+      "path": "/v1/check/dns",
+      "method": "GET",
+      "price": "0.005",
+      "description": "DNS record lookup \u2014 A, AAAA, MX, TXT, NS, CNAME via DNS-over-HTTPS"
+    },
+    {
+      "path": "/v1/check/ssl",
+      "method": "GET",
+      "price": "0.005",
+      "description": "SSL certificate inspection \u2014 issuer, expiry, SANs, days remaining"
+    },
+    {
+      "path": "/v1/check/headers",
+      "method": "GET",
+      "price": "0.003",
+      "description": "HTTP response headers with security headers analysis and score"
+    },
+    {
+      "path": "/v1/convert/html2md",
+      "method": "POST",
+      "price": "0.005",
+      "description": "HTML to Markdown \u2014 preserves headings, lists, links, code blocks, tables"
+    },
+    {
+      "path": "/v1/convert/json2csv",
+      "method": "POST",
+      "price": "0.003",
+      "description": "JSON array to CSV with auto-detected headers"
+    },
+    {
+      "path": "/v1/convert/csv2json",
+      "method": "POST",
+      "price": "0.003",
+      "description": "CSV text to JSON array of objects"
+    },
+    {
+      "path": "/v1/tools/hash",
+      "method": "POST",
+      "price": "0.001",
+      "description": "Hash text with SHA-256, SHA-512, MD5, SHA-1, or SHA3-256"
+    },
+    {
+      "path": "/v1/tools/encode",
+      "method": "POST",
+      "price": "0.001",
+      "description": "Encode/decode text \u2014 Base64, URL encoding, hex"
+    },
+    {
+      "path": "/v1/tools/diff",
+      "method": "POST",
+      "price": "0.003",
+      "description": "Unified diff between two texts with change stats and similarity ratio"
+    },
+    {
+      "path": "/v1/tools/validate/json",
+      "method": "POST",
+      "price": "0.001",
+      "description": "JSON syntax validation with pretty-print and structure info"
+    },
+    {
+      "path": "/v1/tools/validate/email",
+      "method": "POST",
+      "price": "0.002",
+      "description": "Email format validation with MX record check"
+    },
+    {
+      "path": "/v1/data/wikipedia",
+      "method": "GET",
+      "price": "0.01",
+      "description": "Wikipedia article summary \u2014 extract, thumbnail, description, page URL"
+    },
+    {
+      "path": "/v1/data/arxiv",
+      "method": "GET",
+      "price": "0.02",
+      "description": "arXiv academic paper search \u2014 titles, authors, abstracts, PDF links"
+    },
+    {
+      "path": "/v1/data/edgar",
+      "method": "GET",
+      "price": "0.02",
+      "description": "SEC EDGAR filing search \u2014 10-K, 10-Q, 8-K by company, ticker, or keyword"
+    },
+    {
+      "path": "/v1/x402/directory",
+      "method": "GET",
+      "price": "free",
+      "description": "Canonical x402 ecosystem directory \u2014 all known x402 services indexed hourly"
+    },
+    {
+      "path": "/v1/x402/stats",
+      "method": "GET",
+      "price": "free",
+      "description": "x402 ecosystem aggregate statistics \u2014 services by chain, category, growth"
+    },
+    {
+      "path": "/v1/x402/status",
+      "method": "GET",
+      "price": "0.005",
+      "description": "Real-time health and capability check of any x402 service"
+    },
+    {
+      "path": "/v1/x402/route",
+      "method": "POST",
+      "price": "0.001",
+      "description": "Intelligent x402 service routing \u2014 find the best service for your need"
+    },
+    {
+      "path": "/v1/intelligence/pulse",
+      "method": "GET",
+      "price": "0.50",
+      "description": "Hourly regulatory pulse \u2014 aggregated agency activity with composite risk signal"
+    },
+    {
+      "path": "/v1/intelligence/alpha",
+      "method": "GET",
+      "price": "5.00",
+      "description": "Composite alpha signal \u2014 regulatory + Fed + prediction markets + momentum"
+    },
+    {
+      "path": "/v1/intelligence/risk-score",
+      "method": "GET",
+      "price": "2.00",
+      "description": "Real-time 0-100 regulatory risk score for any token or protocol"
+    },
+    {
+      "path": "/v1/intelligence/digest",
+      "method": "GET",
+      "price": "1.00",
+      "description": "Daily regulatory + market digest for compliance teams and trading agents"
+    },
+    {
+      "path": "/v1/intelligence/economic-snapshot",
+      "method": "GET",
+      "price": "0.50",
+      "description": "Atomic real-time economic snapshot \u2014 FRED, BLS, Treasury, FDIC, Federal Register"
+    },
+    {
+      "path": "/v1/intelligence/regulatory-pulse-live",
+      "method": "GET",
+      "price": "0.50",
+      "description": "Live regulatory pulse \u2014 SEC EDGAR, Federal Register, Congress bill tracker"
+    },
+    {
+      "path": "/v1/intelligence/bank-failures",
+      "method": "GET",
+      "price": "0.25",
+      "description": "FDIC bank failure monitor \u2014 recent closures, resolution details, losses"
+    },
+    {
+      "path": "/v1/alerts/subscribe",
+      "method": "POST",
+      "price": "0.10",
+      "description": "Push alert subscription \u2014 webhook delivery of regulatory events. $0.10/100 alerts"
+    },
+    {
+      "path": "/v1/alerts/feed",
+      "method": "GET",
+      "price": "0.05",
+      "description": "Real-time regulatory alert feed \u2014 last 24 hours of detected events"
+    },
+    {
+      "path": "/v1/alerts/status",
+      "method": "GET",
+      "price": "free",
+      "description": "Check alert subscription status and remaining alerts"
+    },
+    {
+      "path": "/v1/portfolio/scan",
+      "method": "POST",
+      "price": "10.00",
+      "description": "Portfolio-level regulatory scan \u2014 up to 20 assets with aggregate risk"
+    },
+    {
+      "path": "/v1/portfolio/watchlist",
+      "method": "POST",
+      "price": "2.00",
+      "description": "Portfolio watchlist \u2014 agency mentions and alert levels for up to 20 assets"
+    },
+    {
+      "path": "/v1/portfolio/market-brief",
+      "method": "GET",
+      "price": "3.00",
+      "description": "Executive market brief \u2014 regulatory + Fed + prediction markets in one view"
+    },
+    {
+      "path": "/v1/orchestrate",
+      "method": "POST",
+      "price": "0.05",
+      "description": "Multi-step orchestration \u2014 execute up to 10 HYDRA calls in one request"
+    },
+    {
+      "path": "/v1/market/prices",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Live crypto prices, market caps, 24h change via CoinGecko \u2014 up to 20 coins"
+    },
+    {
+      "path": "/v1/market/global",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Global crypto market \u2014 total market cap, BTC/ETH dominance, 24h volume"
+    },
+    {
+      "path": "/v1/market/trending",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Top trending cryptocurrencies \u2014 most searched in last 24h"
+    },
+    {
+      "path": "/v1/market/fear-greed",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Crypto Fear & Greed Index \u2014 0-100 score with 7-day history"
+    },
+    {
+      "path": "/v1/market/gas",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Live gas prices across Ethereum, Base, Arbitrum, Optimism, Polygon"
+    },
+    {
+      "path": "/v1/market/stablecoins",
+      "method": "GET",
+      "price": "0.002",
+      "description": "Top 20 stablecoins with circulating supply and real-time peg deviation"
+    },
+    {
+      "path": "/v1/market/defi/tvl",
+      "method": "GET",
+      "price": "0.002",
+      "description": "Top 25 DeFi protocols by TVL with 1d/7d change via DeFi Llama"
+    },
+    {
+      "path": "/v1/market/defi/yields",
+      "method": "GET",
+      "price": "0.005",
+      "description": "Top DeFi yield opportunities \u2014 APY, TVL, IL risk across all chains"
+    },
+    {
+      "path": "/v1/market/defi/chains",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Top 30 blockchains ranked by total DeFi TVL"
+    },
+    {
+      "path": "/v1/market/forex",
+      "method": "GET",
+      "price": "0.001",
+      "description": "Major forex rates from the European Central Bank \u2014 ~30 pairs"
+    },
+    {
+      "path": "/v1/market/snapshot",
+      "method": "GET",
+      "price": "0.05",
+      "description": "Complete market snapshot \u2014 crypto, global, fear/greed, gas, stablecoins"
+    },
+    {
+      "path": "/v1/market/binance/prices",
+      "method": "GET",
+      "price": "0.002",
+      "description": "Real-time Binance prices with 24h volume, high/low, trades, bid/ask"
+    },
+    {
+      "path": "/v1/market/binance/orderbook",
+      "method": "GET",
+      "price": "0.005",
+      "description": "Binance order book \u2014 bids, asks, spread for any trading pair"
+    },
+    {
+      "path": "/v1/market/binance/klines",
+      "method": "GET",
+      "price": "0.005",
+      "description": "Binance OHLCV candlestick data for charting and technical analysis"
+    },
+    {
+      "path": "/v1/market/dex/token",
+      "method": "GET",
+      "price": "0.01",
+      "description": "All DEX pairs for a token across all chains via DexScreener"
+    },
+    {
+      "path": "/v1/market/dex/search",
+      "method": "GET",
+      "price": "0.005",
+      "description": "Search DEX pairs by name, symbol, or address across all chains"
+    },
+    {
+      "path": "/v1/market/bitcoin/fees",
+      "method": "GET",
+      "price": "0.002",
+      "description": "Bitcoin fees, mempool stats, hashrate, difficulty \u2014 real-time"
+    },
+    {
+      "path": "/v1/market/bitcoin/lightning",
+      "method": "GET",
+      "price": "0.002",
+      "description": "Bitcoin Lightning Network \u2014 nodes, channels, capacity, fee rates"
+    },
+    {
+      "path": "/v1/market/treasury/auctions",
+      "method": "GET",
+      "price": "0.005",
+      "description": "U.S. Treasury auction results \u2014 yield, bid-to-cover ratio (Tier 1 gov)"
+    }
   ],
   "docs": "https://hydra-api-nlnj.onrender.com/docs",
   "pricing": "https://hydra-api-nlnj.onrender.com/pricing",
@@ -103,5 +493,56 @@
     "llms_txt": "https://hydra-api-nlnj.onrender.com/.well-known/llms.txt",
     "sitemap": "https://hydra-api-nlnj.onrender.com/sitemap.xml"
   },
-  "tags": ["x402-hub", "ecosystem-directory", "composite-intelligence", "alpha-signal", "risk-score", "push-alerts", "extraction", "search", "web-scraping", "conversion", "developer-tools", "dns", "ssl", "wikipedia", "arxiv", "edgar", "agent-tools", "x402", "regulatory", "prediction-markets", "oracle", "fed", "fomc", "kxfed", "fred", "bls", "treasury", "fdic", "real-time-data", "defi", "crypto-prices", "coingecko", "defi-llama", "tvl", "yields", "stablecoins", "gas-prices", "fear-greed", "forex", "ecb", "market-data", "binance", "orderbook", "klines", "dexscreener", "dex", "bitcoin", "mempool", "lightning", "treasury-auctions"]
+  "tags": [
+    "x402-hub",
+    "ecosystem-directory",
+    "composite-intelligence",
+    "alpha-signal",
+    "risk-score",
+    "push-alerts",
+    "extraction",
+    "search",
+    "web-scraping",
+    "conversion",
+    "developer-tools",
+    "dns",
+    "ssl",
+    "wikipedia",
+    "arxiv",
+    "edgar",
+    "agent-tools",
+    "x402",
+    "regulatory",
+    "prediction-markets",
+    "oracle",
+    "fed",
+    "fomc",
+    "kxfed",
+    "fred",
+    "bls",
+    "treasury",
+    "fdic",
+    "real-time-data",
+    "defi",
+    "crypto-prices",
+    "coingecko",
+    "defi-llama",
+    "tvl",
+    "yields",
+    "stablecoins",
+    "gas-prices",
+    "fear-greed",
+    "forex",
+    "ecb",
+    "market-data",
+    "binance",
+    "orderbook",
+    "klines",
+    "dexscreener",
+    "dex",
+    "bitcoin",
+    "mempool",
+    "lightning",
+    "treasury-auctions"
+  ]
 }


### PR DESCRIPTION
## Summary

Two commits that upgrade HYDRA to v2.0.0 and fix x402 protocol compliance.

### Commit 1: `927c1af` — ops: fix manifests, upgrade CI to Node 24, add FRED_API_KEY
- Updates all static manifests: endpoint count 66+ → 74+, sources 18+ → 22+
- Upgrades all 6 GitHub Actions workflows to Node 24 (Node 20 deprecated June 16)
- Adds `FRED_API_KEY` and `HYDRA_RELAYER_URL` placeholder env vars to render.yaml
- Rewrites deploy-verify.yml with RENDER_API_KEY path, 8min wait, better stale detection

### Commit 2: `5ffc63b` — CRITICAL: x402 protocol compliance fix
- 402 response body now contains standard `x402Version: 2`, `error`, and `accepts[]` array at root
- Previously used custom nested format that failed x402scan crawler validation
- Now fully spec-compliant — x402scan, x402 Bazaar, and all x402 clients can discover payment requirements
- HYDRA extended fields preserved for backward compatibility

### After merge
- Render auto-deploy triggers (autoDeploy: true in render.yaml)
- x402scan submission will pass validation
- ScoutGate and MCP Registry listings become accurate

Wallet: `0x2F12A73e1e08F3BCE12212005cCaBE2ACEf87141` (Base mainnet, USDC)